### PR TITLE
[feature] Bundled errors

### DIFF
--- a/CodeCompanion/app/build.gradle
+++ b/CodeCompanion/app/build.gradle
@@ -21,6 +21,12 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
+
+        debug {
+            applicationIdSuffix ".debug"
+            debuggable true
+        }
+
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/CodeCompanion/app/src/main/AndroidManifest.xml
+++ b/CodeCompanion/app/src/main/AndroidManifest.xml
@@ -14,7 +14,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:usesCleartextTraffic="true"
-        android:theme="@style/Theme.CodeCompanion">
+        android:theme="@style/Theme.CodeCompanion"
+        android:debuggable="true"
+        >
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"
@@ -30,6 +32,11 @@
             android:name="com.journeyapps.barcodescanner.CaptureActivity"
             android:screenOrientation="fullSensor"
             tools:replace="screenOrientation" />
+
+        <service
+            android:name=".services.ErrorMessageRecieverService"
+            >
+        </service>
     </application>
 
 </manifest>

--- a/CodeCompanion/app/src/main/AndroidManifest.xml
+++ b/CodeCompanion/app/src/main/AndroidManifest.xml
@@ -34,7 +34,7 @@
             tools:replace="screenOrientation" />
 
         <service
-            android:name=".services.ErrorMessageRecieverService"
+            android:name=".services.ErrorMessageReceiverService"
             >
         </service>
     </application>

--- a/CodeCompanion/app/src/main/java/com/example/codecompanion/MainActivity.java
+++ b/CodeCompanion/app/src/main/java/com/example/codecompanion/MainActivity.java
@@ -4,13 +4,12 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
-import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.util.Log;
 
-import com.example.codecompanion.services.ErrorMessageRecieverService;
+import com.example.codecompanion.services.ErrorMessageReceiverService;
 import com.example.codecompanion.util.ConnectionStateManager;
 import com.example.codecompanion.util.MessageManager;
 import com.example.codecompanion.util.TaskManager;
@@ -39,7 +38,7 @@ public class MainActivity extends AppCompatActivity {
     private MessageManager messageManager;
     private TaskManager taskManager;
     private ConnectionStateManager connectionStateManager;
-    private ErrorMessageRecieverService errorMessageRecieverService;
+    private ErrorMessageReceiverService errorMessageReceiverService;
     private String id;
     private boolean errorServiceBound = false;
 
@@ -51,7 +50,7 @@ public class MainActivity extends AppCompatActivity {
 
         taskManager = TaskManager.getInstance();
         connectionStateManager = ConnectionStateManager.getInstance();
-        Intent intent = (new Intent(this, ErrorMessageRecieverService.class));
+        Intent intent = (new Intent(this, ErrorMessageReceiverService.class));
         bindService(intent, errorMessageConnection, Context.BIND_AUTO_CREATE);
         messageManager = MessageManager.getInstance();
         createNavigation();
@@ -73,7 +72,7 @@ public class MainActivity extends AppCompatActivity {
                             taskManager.handleTaskInfo(message);
                         }
                     } else {
-                        errorMessageRecieverService.handleMessage(message);
+                        errorMessageReceiverService.handleMessage(message);
                     }
                 } catch (JSONException e) {
                     e.printStackTrace();
@@ -125,10 +124,10 @@ public class MainActivity extends AppCompatActivity {
     private ServiceConnection errorMessageConnection = new ServiceConnection() {
         @Override
         public void onServiceConnected(ComponentName componentName, IBinder iBinder) {
-            ErrorMessageRecieverService.ErrorMessageBinder binder = (ErrorMessageRecieverService.ErrorMessageBinder) iBinder;
-            errorMessageRecieverService = binder.getService();
+            ErrorMessageReceiverService.ErrorMessageBinder binder = (ErrorMessageReceiverService.ErrorMessageBinder) iBinder;
+            errorMessageReceiverService = binder.getService();
             errorServiceBound = true;
-            messageManager.setErrorMessageRecieverService(errorMessageRecieverService);
+            messageManager.setErrorMessageReceiverService(errorMessageReceiverService);
         }
 
         @Override

--- a/CodeCompanion/app/src/main/java/com/example/codecompanion/services/ErrorMessageReceiverService.java
+++ b/CodeCompanion/app/src/main/java/com/example/codecompanion/services/ErrorMessageReceiverService.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-public class ErrorMessageRecieverService extends Service {
+public class ErrorMessageReceiverService extends Service {
 
 	private final IBinder binder = new ErrorMessageBinder();
 
@@ -30,7 +30,7 @@ public class ErrorMessageRecieverService extends Service {
 	private final List<Map<String, String>> warnings;
 	private MessageManager.MessageManagerListener listener;
 
-	public ErrorMessageRecieverService() {
+	public ErrorMessageReceiverService() {
 		errors = new ArrayList<>();
 		warnings = new ArrayList<>();
 	}
@@ -69,8 +69,8 @@ public class ErrorMessageRecieverService extends Service {
 	}
 
 	public class ErrorMessageBinder extends Binder {
-		public ErrorMessageRecieverService getService() {
-			return ErrorMessageRecieverService.this;
+		public ErrorMessageReceiverService getService() {
+			return ErrorMessageReceiverService.this;
 		}
 	}
 

--- a/CodeCompanion/app/src/main/java/com/example/codecompanion/services/ErrorMessageRecieverService.java
+++ b/CodeCompanion/app/src/main/java/com/example/codecompanion/services/ErrorMessageRecieverService.java
@@ -1,0 +1,133 @@
+package com.example.codecompanion.services;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.Binder;
+import android.os.IBinder;
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+
+import com.example.codecompanion.util.MessageManager;
+import com.google.gson.Gson;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class ErrorMessageRecieverService extends Service {
+
+	private final IBinder binder = new ErrorMessageBinder();
+
+	private final List<Map<String, String>> errors;
+	private final List<Map<String, String>> warnings;
+	private MessageManager.MessageManagerListener listener;
+
+	public ErrorMessageRecieverService() {
+		errors = new ArrayList<>();
+		warnings = new ArrayList<>();
+	}
+
+	@Nullable
+	@Override
+	public IBinder onBind(Intent intent) {
+		return binder;
+	}
+
+	public void handleMessage(String data) throws JSONException {
+		List<Map<String,String>> unpackedMessageList = new ArrayList<>();
+
+		JSONArray jsonArray = new JSONArray(data);
+		List<String> messages = new Gson().fromJson(jsonArray.toString(), ArrayList.class);
+		for (String message : messages) {
+			Log.d("message", message);
+			unpackedMessageList.add(unpackString(message));
+		}
+
+		for (Map<String, String> map : unpackedMessageList) {
+			if (Objects.equals(map.get("add/remove"), "add")) {
+				addMessage(map);
+			} else if (Objects.equals(map.get("add/remove"), "remove")) {
+				removeMessage(map);
+			}
+		}
+	}
+
+	public List<Map<String, String>> getErrors() {
+		return errors;
+	}
+
+	public List<Map<String, String>> getWarnings() {
+		return warnings;
+	}
+
+	public class ErrorMessageBinder extends Binder {
+		public ErrorMessageRecieverService getService() {
+			return ErrorMessageRecieverService.this;
+		}
+	}
+
+	private void addMessage(Map<String, String> message){
+		String tag = message.get("tag");
+		if ("WARNING".equals(tag)) {
+			warnings.add(message);
+		} else if ("ERROR".equals(tag)) {
+			errors.add(message);
+		}
+		notifyDataChanged();
+	}
+
+	private void removeMessage(Map<String, String> message) {
+		String id = message.get("id");
+
+		for (Iterator<Map<String, String>> iterator = warnings.iterator(); iterator.hasNext();) {
+			Map<String, String> warning = iterator.next();
+			if (Objects.equals(warning.get("id"), id)) {
+				iterator.remove();
+				notifyDataChanged();
+				return;
+			}
+		}
+
+		for (Iterator<Map<String, String>> iterator = errors.iterator(); iterator.hasNext();) {
+			Map<String, String> error = iterator.next();
+			if (Objects.equals(error.get("id"), id)) {
+				iterator.remove();
+				notifyDataChanged();
+				return;
+			}
+		}
+	}
+
+	private HashMap<String,String> unpackString(String message) throws JSONException {
+		JSONObject jsonObject = new JSONObject(message);
+		HashMap<String, String> messageMap = new Gson().fromJson(jsonObject.toString(), HashMap.class);
+		Log.d("Test",messageMap.toString());
+		return messageMap;
+	}
+
+	private void notifyDataChanged() {
+		if(listener != null) {
+			listener.onDataChanged();
+		}
+	}
+
+	public IBinder getBinder() {
+		return binder;
+	}
+
+	public MessageManager.MessageManagerListener getListener() {
+		return listener;
+	}
+
+	public void setListener(MessageManager.MessageManagerListener listener) {
+		this.listener = listener;
+	}
+}

--- a/CodeCompanion/app/src/main/java/com/example/codecompanion/ui/compiler/CompilerFragment.java
+++ b/CodeCompanion/app/src/main/java/com/example/codecompanion/ui/compiler/CompilerFragment.java
@@ -53,30 +53,18 @@ public class CompilerFragment extends Fragment {
             compilerMessageField.setText("> seems to work correctly.");
         }
         super.onResume();
-        messageManager.setListener(new MessageManager.MessageManagerListener() {
-            @Override
-            public void onDataChanged() {
-                getActivity().runOnUiThread(new Runnable() {
-                    @Override
-                    public void run() {
-                        data.clear();
-                        for (Map error: messageManager.getErrors()) {
-                            data.add(error);
-                        }
-                        for (Map warning:messageManager.getWarnings()) {
-                            data.add(warning);
-                        }
+        messageManager.setListener(() -> getActivity().runOnUiThread(() -> {
+            data.clear();
+            data.addAll(messageManager.getErrors());
+            data.addAll(messageManager.getWarnings());
 
-                        if(data.size() > 0) {
-                            compilerMessageField.setText("> i think you have some errors...");
-                        } else {
-                            compilerMessageField.setText("> seems to work correctly.");
-                        }
-                        adapter.notifyDataSetChanged();
-                    }
-                });
+            if(data.size() > 0) {
+                compilerMessageField.setText("> i think you have some errors...");
+            } else {
+                compilerMessageField.setText("> seems to work correctly.");
             }
-        });
+            adapter.notifyDataSetChanged();
+        }));
     }
 
     @Override

--- a/CodeCompanion/app/src/main/java/com/example/codecompanion/util/MessageManager.java
+++ b/CodeCompanion/app/src/main/java/com/example/codecompanion/util/MessageManager.java
@@ -2,6 +2,7 @@ package com.example.codecompanion.util;
 
 import android.util.Log;
 
+import com.example.codecompanion.services.ErrorMessageRecieverService;
 import com.google.gson.Gson;
 
 import org.json.JSONArray;
@@ -10,23 +11,22 @@ import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class MessageManager {
 
     public interface MessageManagerListener{
-        public void onDataChanged();
+        void onDataChanged();
     }
 
-    private List<Map> errors;
-    private List<Map> warnings;
-    private MessageManagerListener listener;
     private static MessageManager instance;
+    private ErrorMessageRecieverService errorMessageRecieverService;
 
     private MessageManager() {
-        errors = new ArrayList<>();
-        warnings = new ArrayList<>();
+
     }
 
     public static MessageManager getInstance(){
@@ -36,68 +36,27 @@ public class MessageManager {
         return MessageManager.instance;
     }
 
-    public void handleMessage(String message) throws JSONException {
-        if(message.equals("ERROR LOG STARTED")){
-            removeAll();
-        }else{
-            HashMap<String, String> messageMap = unpackString(message);
-            String desc = messageMap.get("description");
-            String line = messageMap.get("line");
-            String type = messageMap.get("type");
-            String oc = messageMap.get("ocurence");
-            String messageText = oc + ": " + line + "\n" + type + "\n" + desc;
-
-            Map convertedMessage = new HashMap();
-            convertedMessage.put("tag", messageMap.get("tag"));
-            convertedMessage.put("text", messageText);
-
-            addMessage(convertedMessage);
-        }
+    public List<Map<String, String>> getErrors() {
+        return errorMessageRecieverService.getErrors();
     }
 
-    public void addMessage(Map message){
-        Object tag = message.get("tag");
-        if ("WARNING".equals(tag)) {
-            warnings.add(message);
-        } else if ("ERROR".equals(tag)) {
-            errors.add(message);
-        }
-        if(listener != null) {
-            listener.onDataChanged();
-        }
-    }
-
-    public void removeAll(){
-        errors.clear();
-        warnings.clear();
-        if(listener != null) {
-            listener.onDataChanged();
-        }
-    }
-
-    public List<Map> getErrors() {
-        return errors;
-    }
-
-    public List<Map> getWarnings() {
-        return warnings;
+    public List<Map<String, String>> getWarnings() {
+        return errorMessageRecieverService.getWarnings();
     }
 
     public void setListener(MessageManagerListener listener){
-        this.listener = listener;
+        errorMessageRecieverService.setListener(listener);
     }
 
     public void removeListener(){
-        this.listener = null;
+        errorMessageRecieverService.setListener(null);
     }
 
-
-    private HashMap<String,String> unpackString(String message) throws JSONException {
-        JSONObject jsonObject = new JSONObject(message);
-        HashMap<String, String> messageMap = new Gson().fromJson(jsonObject.toString(), HashMap.class);
-        Log.d("Test",messageMap.toString());
-        return messageMap;
+    public ErrorMessageRecieverService getErrorMessageRecieverService() {
+        return errorMessageRecieverService;
     }
-    
 
+    public void setErrorMessageRecieverService(ErrorMessageRecieverService errorMessageRecieverService) {
+        this.errorMessageRecieverService = errorMessageRecieverService;
+    }
 }

--- a/CodeCompanion/app/src/main/java/com/example/codecompanion/util/MessageManager.java
+++ b/CodeCompanion/app/src/main/java/com/example/codecompanion/util/MessageManager.java
@@ -1,20 +1,9 @@
 package com.example.codecompanion.util;
 
-import android.util.Log;
+import com.example.codecompanion.services.ErrorMessageReceiverService;
 
-import com.example.codecompanion.services.ErrorMessageRecieverService;
-import com.google.gson.Gson;
-
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 public class MessageManager {
 
@@ -23,7 +12,7 @@ public class MessageManager {
     }
 
     private static MessageManager instance;
-    private ErrorMessageRecieverService errorMessageRecieverService;
+    private ErrorMessageReceiverService errorMessageReceiverService;
 
     private MessageManager() {
 
@@ -37,26 +26,26 @@ public class MessageManager {
     }
 
     public List<Map<String, String>> getErrors() {
-        return errorMessageRecieverService.getErrors();
+        return errorMessageReceiverService.getErrors();
     }
 
     public List<Map<String, String>> getWarnings() {
-        return errorMessageRecieverService.getWarnings();
+        return errorMessageReceiverService.getWarnings();
     }
 
     public void setListener(MessageManagerListener listener){
-        errorMessageRecieverService.setListener(listener);
+        errorMessageReceiverService.setListener(listener);
     }
 
     public void removeListener(){
-        errorMessageRecieverService.setListener(null);
+        errorMessageReceiverService.setListener(null);
     }
 
-    public ErrorMessageRecieverService getErrorMessageRecieverService() {
-        return errorMessageRecieverService;
+    public ErrorMessageReceiverService getErrorMessageReceiverService() {
+        return errorMessageReceiverService;
     }
 
-    public void setErrorMessageRecieverService(ErrorMessageRecieverService errorMessageRecieverService) {
-        this.errorMessageRecieverService = errorMessageRecieverService;
+    public void setErrorMessageReceiverService(ErrorMessageReceiverService errorMessageReceiverService) {
+        this.errorMessageReceiverService = errorMessageReceiverService;
     }
 }

--- a/CodeCompanion/app/src/main/java/com/example/codecompanion/util/MessageViewAdapter.java
+++ b/CodeCompanion/app/src/main/java/com/example/codecompanion/util/MessageViewAdapter.java
@@ -96,7 +96,7 @@ public class MessageViewAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
      */
     @Override
     public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
-        String message = (String) localDataSet.get(position).get("text");
+        String message = (String) localDataSet.get(position).get("description");
         if(getItemViewType(position) == TYPE_ERROR) {
             ((ErrorViewHolder) holder).textView.setText(message);
         } else {

--- a/CodeCompanion/app/src/main/java/com/example/codecompanion/util/WebRTC.java
+++ b/CodeCompanion/app/src/main/java/com/example/codecompanion/util/WebRTC.java
@@ -26,7 +26,6 @@ import io.socket.client.Socket;
 import static io.socket.client.Socket.EVENT_CONNECT;
 import static io.socket.client.Socket.EVENT_DISCONNECT;
 import static org.webrtc.SessionDescription.Type.ANSWER;
-import static org.webrtc.SessionDescription.Type.OFFER;
 
 public class WebRTC {
 
@@ -147,7 +146,7 @@ public class WebRTC {
                         final byte[] bytes = new byte[data.capacity()];
                         data.get(bytes);
                         String strData = new String(bytes);
-                        listener.onMessageRecieved(strData);
+                        listener.onMessageReceived(strData);
                         Log.d(TAG, "Got msg: " + strData + " over " + dc1);
                     }
                 });
@@ -180,6 +179,6 @@ public class WebRTC {
 
     public interface WebRTCListener{
         public void onConnectionStateChanged(PeerConnection.PeerConnectionState state);
-        public void onMessageRecieved(String message);
+        public void onMessageReceived(String message);
     }
 }

--- a/Plugin/src/main/java/app/MessageHandler.java
+++ b/Plugin/src/main/java/app/MessageHandler.java
@@ -8,46 +8,96 @@ import com.intellij.openapi.editor.Document;
 import dev.onvoid.webrtc.RTCDataChannelState;
 import dev.onvoid.webrtc.RTCPeerConnectionState;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class MessageHandler {
 
     private final ApplicationService manager;
     private WebRTC webRTC;
+    private final Map<HighlightInfo, Long> alreadyPresentErrors = new HashMap<>();
+    private List<String> messages;
+    private final Gson gson = new Gson();
+    private final String ADD_ERROR_TAG = "add";
+    private final String REMOVE_ERROR_TAG = "remove";
+    private long messageId = 0;
 
     public MessageHandler() {
         manager = ServiceManager.getService(ApplicationService.class);
     }
 
     public void handleMessage(List<HighlightInfo> highlightInfoList, Document document) throws Exception {
+        messages = new ArrayList<>();
         makeString(highlightInfoList, document);
+        checkForRemovedErrors(highlightInfoList);
+        send(gson.toJson(messages));
+    }
+
+    /**
+     * Checks for errors that were recorded but are no longer present
+     * Use {@link Iterator} in loop instead of foreach to avoid {@link ConcurrentModificationException}
+     * @param highlightInfoList the List of currently present errors
+     */
+    private void checkForRemovedErrors(List<HighlightInfo> highlightInfoList) {
+        for (Iterator<HighlightInfo> iterator = alreadyPresentErrors.keySet().iterator(); iterator.hasNext();) {
+            HighlightInfo alreadyPresentError = iterator.next();
+            if (!highlightInfoList.contains(alreadyPresentError)) {
+                addRemoveErrorMessage(alreadyPresentError);
+                iterator.remove();
+            }
+        }
+    }
+
+    /**
+     * Add a message that specifies removal of a no longer present error
+     * @param alreadyPresentError the error that should be removed from the list in the app
+     */
+    private void addRemoveErrorMessage(HighlightInfo alreadyPresentError) {
+        Map<String, String> message = new HashMap<>();
+
+        message.put("add/remove", REMOVE_ERROR_TAG);
+        message.put("id", "" + alreadyPresentErrors.get(alreadyPresentError));
+
+        String json = gson.toJson(message);
+        messages.add(json);
+    }
+
+    /**
+     * Add a message that adds a new error to the list in our app
+     * @param highlightInfo contains all information about the error
+     * @param document the current document, needed to determine the line of the error
+     */
+    private void addNewErrorMessage(HighlightInfo highlightInfo, Document document) {
+        Map<String,String> message = new HashMap<>();
+
+        String type = highlightInfo.type.getAttributesKey().toString();
+        String line = Integer.toString(1 + document.getLineNumber(highlightInfo.startOffset));
+        String description = highlightInfo.getDescription();
+        String occurence = highlightInfo.getText();
+        String tag = highlightInfo.getSeverity().toString();
+
+        message.put("add/remove", ADD_ERROR_TAG);
+        message.put("tag",tag);
+        message.put("type",type);
+        message.put("ocurence", occurence); // typo --> occurrence / used on android side? fix later?
+        message.put("line", line);
+        message.put("description", description);
+        message.put("id", "" + ++messageId);
+
+        String json = gson.toJson(message);
+        messages.add(json);
     }
 
     private void makeString(List<HighlightInfo> highlightInfoList, Document document) throws Exception {
-        send("ERROR LOG STARTED");
-        for(int i = 0; i < highlightInfoList.size();i++){
-            Map<String,String> message = new HashMap();
 
-            String type = highlightInfoList.get(i).type.getAttributesKey().toString();
-            String line = Integer.toString(1 + document.getLineNumber(highlightInfoList.get(i).startOffset));
-            String description = highlightInfoList.get(i).getDescription();
-            String occurence = highlightInfoList.get(i).getText();
-            String tag = highlightInfoList.get(i).getSeverity().toString();
+        for (HighlightInfo highlightInfo : highlightInfoList) {
+            if (alreadyPresentErrors.containsKey(highlightInfo)) {
+                continue;
+            }
 
-            message.put("tag",tag);
-            message.put("type",type);
-            message.put("ocurence", occurence);
-            message.put("line", line);
-            message.put("description", description);
-
-            String json = new Gson().toJson(message);
-            System.out.println(json);
-            send(json);
-
+            addNewErrorMessage(highlightInfo, document);
+            alreadyPresentErrors.put(highlightInfo, messageId);
         }
+
     }
 
     public void send(String data) throws Exception {

--- a/Plugin/src/main/java/app/services/application/ApplicationService.java
+++ b/Plugin/src/main/java/app/services/application/ApplicationService.java
@@ -5,6 +5,7 @@ import app.TaskHandler;
 import app.WebRTC;
 import app.listeners.ListenerHelper;
 import com.intellij.openapi.components.ServiceManager;
+import dev.onvoid.webrtc.RTCDataChannelState;
 import dev.onvoid.webrtc.RTCPeerConnectionState;
 
 import java.util.UUID;
@@ -40,7 +41,6 @@ public class ApplicationService implements WebRTC.WebRTCListener {
 
         state = ApplicationState.RECORDING;
         webRTC = new WebRTC();
-        messageHandler = new MessageHandler();
         taskHandler.init();
         UUID uuid = UUID.randomUUID();
         String stringId = uuid.toString();
@@ -71,6 +71,10 @@ public class ApplicationService implements WebRTC.WebRTCListener {
     public void onConnectionStateChanged(RTCPeerConnectionState state) {
         if(listener != null){
             listener.onConnectionStateChanged(state);
+        }
+
+        if (state == RTCPeerConnectionState.CONNECTED) {
+            messageHandler = new MessageHandler();
         }
     }
 


### PR DESCRIPTION
Now sends errors/warnings only when a new one is made or an old one is removed.
All errors are now sent in a single call of send() instead of lots of single messages for every error/warning.

Since the errors are now not being sent all the time, I also had to update the Android App:
Listening for Errors/Warnings now happens in a Service. This is needed, since errors are only sent once, and if this happens while the app is minimized (or the user is in a different fragment) the message would be ignored.