### PR TITLE
[feature] link to google query from error description

### DIFF
--- a/CodeCompanion/app/build.gradle
+++ b/CodeCompanion/app/build.gradle
@@ -57,4 +57,6 @@ dependencies {
         exclude group: 'org.json', module: 'json'
     }
     implementation("org.webrtc:google-webrtc:1.0.27771")
+
+    implementation('joda-time:joda-time:2.10.10')
 }

--- a/CodeCompanion/app/src/main/java/com/example/codecompanion/ui/compiler/ExpandedMessageFragment.java
+++ b/CodeCompanion/app/src/main/java/com/example/codecompanion/ui/compiler/ExpandedMessageFragment.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
 public class ExpandedMessageFragment extends Fragment {
 
     private final String GOOGLE_QUERY_STRING = "https://www.google.com/search?q=";
-    private final int BUTTON_TIMEOUT_IN_MILLISECONDS = 250;
+    private final int BUTTON_TIMEOUT_IN_MILLISECONDS = 250; // used to prevent accidental doubletaps
 
     private TextView errorDescription;
     private final String explanation;
@@ -50,8 +50,8 @@ public class ExpandedMessageFragment extends Fragment {
         this.explanation = shortExplanation;
         this.textViewId = textViewId;
         this.error = error;
-        phoneButtonClickedTime = DateTime.now().minusSeconds(10); // initial value: 2020-01-01T00:00:00Z
-        desktopButtonClickedTime = DateTime.now().minusSeconds(10); // initial value: 2020-01-01T00:00:00Z
+        phoneButtonClickedTime = DateTime.now().minusSeconds(10);
+        desktopButtonClickedTime = DateTime.now().minusSeconds(10);
         MainActivity.isExpandedMessageOpen = true;
     }
 

--- a/CodeCompanion/app/src/main/java/com/example/codecompanion/ui/compiler/ExpandedMessageFragment.java
+++ b/CodeCompanion/app/src/main/java/com/example/codecompanion/ui/compiler/ExpandedMessageFragment.java
@@ -1,7 +1,10 @@
 package com.example.codecompanion.ui.compiler;
 
+import android.content.Intent;
 import android.content.res.ColorStateList;
+import android.net.Uri;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -14,19 +17,41 @@ import androidx.fragment.app.Fragment;
 
 import com.example.codecompanion.MainActivity;
 import com.example.codecompanion.R;
+import com.example.codecompanion.services.WebRTC;
+import com.example.codecompanion.util.ConnectionStateManager;
+import com.google.gson.Gson;
 
 import org.jetbrains.annotations.NotNull;
+import org.joda.time.DateTime;
+import org.joda.time.Period;
+import org.joda.time.PeriodType;
+import org.webrtc.PeerConnection;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
 
 public class ExpandedMessageFragment extends Fragment {
 
+    private final String GOOGLE_QUERY_STRING = "https://www.google.com/search?q=";
+    private final int BUTTON_TIMEOUT_IN_MILLISECONDS = 250;
+
     private TextView errorDescription;
     private final String explanation;
+    private String error;
     private ImageView icon;
     private final int textViewId;
+    private TextView desktopLink;
+    private TextView phoneLink;
+    private DateTime phoneButtonClickedTime;
+    private DateTime desktopButtonClickedTime;
 
-    public ExpandedMessageFragment(String shortExplanation, int textViewId) {
+    public ExpandedMessageFragment(String shortExplanation, int textViewId, String error) {
         this.explanation = shortExplanation;
         this.textViewId = textViewId;
+        this.error = error;
+        phoneButtonClickedTime = DateTime.now().minusSeconds(10); // initial value: 2020-01-01T00:00:00Z
+        desktopButtonClickedTime = DateTime.now().minusSeconds(10); // initial value: 2020-01-01T00:00:00Z
         MainActivity.isExpandedMessageOpen = true;
     }
 
@@ -41,7 +66,66 @@ public class ExpandedMessageFragment extends Fragment {
         errorDescription.setText(explanation);
 
         icon = view.findViewById(R.id.exp_message_icon);
+        desktopLink = view.findViewById(R.id.dekstop_link_textview);
+        phoneLink = view.findViewById(R.id.phone_link_textview);
+
+        prepareErrorForUrl();
         setIcon(textViewId);
+        setLinks();
+    }
+
+    // formats the query url by replacing spaces for '+' and adds the suffix "Java"
+    private void prepareErrorForUrl() {
+        error = error.replace(" ", "+");
+        error += "+Java";
+    }
+
+    private void setLinks() {
+        // add click listeners to the TextViews
+        setPhoneLink();
+        setDesktopLink();
+    }
+
+    private void setDesktopLink() {
+        desktopLink.setOnClickListener(view -> {
+            if (isButtonOnTimeout(desktopButtonClickedTime)) {
+                return;
+            }
+
+            desktopButtonClickedTime = DateTime.now();
+            Map<String, String> message = new HashMap<>();
+            message.put("google-query", GOOGLE_QUERY_STRING + error);
+            String messageString = new Gson().toJson(message);
+
+            if (ConnectionStateManager.getInstance().getConnectionState() == PeerConnection.PeerConnectionState.CONNECTED) {
+                try {
+                    WebRTC.sendData(messageString);
+                } catch (Exception e) {
+                    Log.e("WebRTC", "Could not send message for Google Query");
+                    e.printStackTrace();
+                }
+            }
+        });
+    }
+
+    private void setPhoneLink() {
+        phoneLink.setOnClickListener(view -> {
+            if (!isButtonOnTimeout(phoneButtonClickedTime)) {
+                phoneButtonClickedTime = DateTime.now();
+                Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(GOOGLE_QUERY_STRING + error));
+                startActivity(browserIntent);
+            }
+        });
+    }
+
+    // method to check if button is on timeout - to prevent accidental doubletaps
+    // app will crash here if user leaves message fragment open for longer than 25 days.
+    // let's hope that this will not happen
+    private boolean isButtonOnTimeout(DateTime buttonClickedTime) {
+        DateTime now = DateTime.now();
+        Period period = new Period(buttonClickedTime, now, PeriodType.millis());
+
+        return period.getMillis() < BUTTON_TIMEOUT_IN_MILLISECONDS;
     }
 
     public void setText(String text) {

--- a/CodeCompanion/app/src/main/java/com/example/codecompanion/util/AbstractCompilerMessageViewHolder.java
+++ b/CodeCompanion/app/src/main/java/com/example/codecompanion/util/AbstractCompilerMessageViewHolder.java
@@ -22,7 +22,7 @@ public abstract class AbstractCompilerMessageViewHolder extends RecyclerView.Vie
 		layout = (ConstraintLayout) view.findViewById(layoutId);
 		layout.setOnClickListener(v -> {
 			AppCompatActivity activity = (AppCompatActivity) view.getContext();
-			fragment = new ExpandedMessageFragment(shortExplanation, textViewId);
+			fragment = new ExpandedMessageFragment(shortExplanation, textViewId, textView.getText().toString());
 			activity.getSupportFragmentManager().beginTransaction().replace(R.id.nav_host_fragment, fragment).addToBackStack("expandedMessage").commit();
 		});
 	}

--- a/CodeCompanion/app/src/main/res/layout/fragment_expanded_description.xml
+++ b/CodeCompanion/app/src/main/res/layout/fragment_expanded_description.xml
@@ -52,6 +52,56 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/exp_message_icon" />
 
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/open_link_textview"
+            android:textColor="@color/white"
+            android:fontFamily="serif-monospace"
+            android:paddingTop="16dp"
+            android:paddingLeft="24dp"
+            android:text="Look up error on device: "
+            app:layout_constraintTop_toBottomOf="@+id/expanded_message"
+            app:layout_constraintLeft_toLeftOf="@+id/expanded_message"
+
+            />
+
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/dekstop_link_textview"
+            android:clickable="true"
+            android:focusable="true"
+            android:textColor="@color/link_color"
+            android:fontFamily="serif-monospace"
+            android:textSize="20sp"
+            android:paddingTop="16dp"
+            android:paddingLeft="24dp"
+            android:text="@string/desktop"
+            app:layout_constraintTop_toBottomOf="@+id/open_link_textview"
+            app:layout_constraintLeft_toLeftOf="@+id/expanded_message"
+
+            />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/phone_link_textview"
+            android:clickable="true"
+            android:focusable="true"
+            android:textColor="@color/link_color"
+            android:fontFamily="serif-monospace"
+            android:textSize="20sp"
+            android:paddingTop="16dp"
+            android:paddingLeft="24dp"
+            android:text="@string/phone"
+            app:layout_constraintTop_toBottomOf="@+id/open_link_textview"
+            app:layout_constraintLeft_toRightOf="@+id/dekstop_link_textview"
+
+            />
+
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/CodeCompanion/app/src/main/res/values/colors.xml
+++ b/CodeCompanion/app/src/main/res/values/colors.xml
@@ -28,6 +28,7 @@
     <color name="primary_color2">#FF8D29</color>
     <color name="primary_color3">#F12F58</color>
     <color name="primary_color4">#1E88E5</color>
+    <color name="link_color">#1E88E5</color>
 
 
 

--- a/CodeCompanion/app/src/main/res/values/strings.xml
+++ b/CodeCompanion/app/src/main/res/values/strings.xml
@@ -60,5 +60,7 @@
     <string name="second_tutorial_text"><![CDATA[In IntelliJ you have to download and install the Code Companion Plugin under Settings > Plugins > Search for \'Code Companion\'.\nAfter installing IntelliJ has to be restarted.]]></string>
     <string name="third_tutorial_text">Now you can open the \'Code Companion\' tool window on the right side of your IntelliJ window. Scan the QR-Code shown in IntelliJ with your app. Once connected, the icon on the home page of your app shows a green checkmark.</string>
     <string name="fourth_tutorial_message">Errors, Warnings and your To-Do List are now transferred live to your app. Tap on them to get more information about the meaning of the message.</string>
+    <string name="phone"><u>Phone</u></string>
+    <string name="desktop"><u>Desktop</u></string>
 
 </resources>

--- a/Plugin/src/main/java/app/MessageHandler.java
+++ b/Plugin/src/main/java/app/MessageHandler.java
@@ -1,7 +1,9 @@
 package app;
 
+import app.data.Const;
 import app.services.application.ApplicationService;
 import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import com.intellij.codeInsight.daemon.impl.HighlightInfo;
 import com.intellij.lang.annotation.HighlightSeverity;
 import com.intellij.openapi.components.ServiceManager;
@@ -9,8 +11,16 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.colors.TextAttributesKey;
 import dev.onvoid.webrtc.RTCDataChannelState;
 import dev.onvoid.webrtc.RTCPeerConnectionState;
+import netscape.javascript.JSObject;
+import org.junit.Assert;
 
+import java.awt.*;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.*;
+import java.util.List;
 
 public class MessageHandler {
 
@@ -145,6 +155,20 @@ public class MessageHandler {
             send(gson.toJson(messagesToSend));
         } catch (Exception e) {
             System.out.println("Refresh data failed!");
+            e.printStackTrace();
+        }
+
+    }
+
+    public void openGoogleQuery(String message) {
+        Type type = new TypeToken<Map<String, String>>() {}.getType();
+        Map<String, String> map = gson.fromJson(message, type);
+        Assert.assertEquals(1, map.size());
+
+        try {
+            URI url = new URI(map.get(Const.Events.GOOGLE_QUERY_MESSAGE));
+            Desktop.getDesktop().browse(url);
+        } catch (IOException | URISyntaxException e) {
             e.printStackTrace();
         }
 

--- a/Plugin/src/main/java/app/data/Const.java
+++ b/Plugin/src/main/java/app/data/Const.java
@@ -4,5 +4,6 @@ public class Const {
 
     public static class Events {
         public static final String REFRESH_DATA_MESSAGE = "REFRESH_DATA";
+        public static final String GOOGLE_QUERY_MESSAGE = "google-query";
     }
 }

--- a/Plugin/src/main/java/app/services/application/ApplicationService.java
+++ b/Plugin/src/main/java/app/services/application/ApplicationService.java
@@ -101,6 +101,10 @@ public class ApplicationService implements WebRTC.WebRTCListener {
         if (message.equals(Const.Events.REFRESH_DATA_MESSAGE)) {
             messageHandler.handleRefreshData();
         }
+
+        if (message.contains(Const.Events.GOOGLE_QUERY_MESSAGE)) {
+            messageHandler.openGoogleQuery(message);
+        }
     }
 
     @Override


### PR DESCRIPTION
Added two new buttons to the expanded error descriptions. These buttons open a google query for the error on either the connected PC or the user's phone.

For testing:
- Connect the app with the IDE
- Create an Error/Warning and tap on it to view the details
- Click on the "Desktop" / "Phone" links at the bottom
A browser window should open and show results on Google